### PR TITLE
safer and faster way for globalizing selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "homepage": "https://github.com/scherebedov/postcss-global-import#readme",
   "dependencies": {
-    "postcss": "^6.0.2",
+    "css-selector-tokenizer": "^0.7.0",
+    "postcss": "^6.0.14",
     "resolve": "^1.1.7"
   },
   "engine": "node >= 6.0.0",

--- a/tests/fixtures.test.js
+++ b/tests/fixtures.test.js
@@ -15,9 +15,11 @@ function processCss(file) {
   const css = `@global-import "${file}"`;
 
   return new Promise(resolve => {
-    postcss([globalImport, modules({
-      getJSON: ()=> {}
-    }), cssnano()])
+    postcss([
+      globalImport,
+      modules({ getJSON: ()=> {} }),
+      cssnano()
+    ])
       .process(css, { from: masterPath, to: '_.css' })
       .then(result => {
         resolve(result.css);

--- a/tests/fixtures/multiple-selectors.css
+++ b/tests/fixtures/multiple-selectors.css
@@ -1,0 +1,4 @@
+
+.foo#content.active > .bar::first-line [data-content], .foo:not(:visited) {
+  color: red;
+}

--- a/tests/fixtures/simple.css
+++ b/tests/fixtures/simple.css
@@ -1,3 +1,7 @@
 .foo {
   top: 1px;
 }
+
+.foo:focus {
+  color: red;
+}


### PR DESCRIPTION
fixes following case

```css
.foo,
.foo:hover {
  color: red
}
```

Or even more complicated one:

```css
.foo#content.active > .bar::first-line [data-content], .foo:not(.red) {
}
```